### PR TITLE
Show/Hide Button for Assignees and Milestones

### DIFF
--- a/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
@@ -41,11 +41,11 @@ export class AssigneeGroupingStrategy implements GroupingStrategy {
   }
 
   /**
-   * Groups other than "No Assignee" need to be shown on the
-   * hidden group list if empty.
+   * Show all groups in the hidden list.
+   * Determines if a group is in the hidden list.
    */
   isInHiddenList(group: GithubUser): boolean {
-    return group !== GithubUser.NO_ASSIGNEE;
+    return true; // All groups are shown in the hidden list.
   }
 
   private getDataAssignedToUser(issues: Issue[], user: GithubUser): Issue[] {

--- a/src/app/core/services/grouping/milestone-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/milestone-grouping-strategy.service.ts
@@ -37,10 +37,10 @@ export class MilestoneGroupingStrategy implements GroupingStrategy {
   }
 
   /**
-   * Groups other than Default Milestone need to be shown on the
-   * hidden group list if empty.
+   * Show all milestones in the hidden list.
+   * Determines if a milestone is in the hidden list.
    */
   isInHiddenList(group: Milestone): boolean {
-    return group !== Milestone.IssueWithoutMilestone && group !== Milestone.PRWithoutMilestone;
+    return true;
   }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -144,7 +144,7 @@ div.column-header .mat-card-header {
   margin-top: 3px;
 }
 
-.hide-assignee-button {
+.hide-button {
   cursor: pointer;
   display: inline-flex;
   font-size: 14px;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -144,6 +144,15 @@ div.column-header .mat-card-header {
   margin-top: 3px;
 }
 
+.hide-assignee-button {
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 14px;
+  padding: 6px 8px 3px 8px;
+  color: rgb(0, 0, 0);
+  font-weight: 410;
+}
+
 .assignee-container {
   width: 100%;
   text-align: left;

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -53,7 +53,7 @@
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>
-            <div class="hide-assignee-button" matTooltip="Hide Assignee" matTooltipPosition="above">
+            <div class="hide-button" [matTooltip]="getHiddenTooltip()" matTooltipPosition="above">
               <span class="octicon" octicon="eye-closed"></span>
             </div>
           </div>
@@ -79,6 +79,9 @@
             <div class="row-count" [matTooltip]="getPrTooltip()" matTooltipPosition="above">
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
+            </div>
+            <div class="hide-button" [matTooltip]="getHiddenTooltip()" matTooltipPosition="above">
+              <span class="octicon" octicon="eye-closed"></span>
             </div>
           </div>
         </mat-card-title>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -53,6 +53,9 @@
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>
+            <div class="hide-assignee-button" matTooltip="Hide Assignee" matTooltipPosition="above">
+              <span class="octicon" octicon="eye-closed"></span>
+            </div>
           </div>
         </mat-card-title>
       </mat-card-header>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -53,7 +53,7 @@
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>
-            <div class="hide-button" [matTooltip]="getHiddenTooltip()" matTooltipPosition="above">
+            <div class="hide-button" [matTooltip]="getHiddenButtonTooltip()" matTooltipPosition="above" (click)="hideAssignee(assignee)">
               <span class="octicon" octicon="eye-closed"></span>
             </div>
           </div>
@@ -80,7 +80,7 @@
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>
-            <div class="hide-button" [matTooltip]="getHiddenTooltip()" matTooltipPosition="above">
+            <div class="hide-button" [matTooltip]="getHiddenButtonTooltip()" matTooltipPosition="above" (click)="hideMilestone(milestone)">
               <span class="octicon" octicon="eye-closed"></span>
             </div>
           </div>

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -145,4 +145,13 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   getPrTooltip(): string {
     return this.issues.prCount + ' Pull Requests';
   }
+
+  getHiddenTooltip(): string {
+    if (this.groupingContextService.currGroupBy === GroupBy.Assignee) {
+      return 'Hide Assignee';
+    } else if (this.groupingContextService.currGroupBy === GroupBy.Milestone) {
+      return 'Hide Milestone';
+    }
+    return '';
+  }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -146,12 +146,22 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
     return this.issues.prCount + ' Pull Requests';
   }
 
-  getHiddenTooltip(): string {
+  getHiddenButtonTooltip(): string {
     if (this.groupingContextService.currGroupBy === GroupBy.Assignee) {
       return 'Hide Assignee';
     } else if (this.groupingContextService.currGroupBy === GroupBy.Milestone) {
       return 'Hide Milestone';
     }
     return '';
+  }
+
+  hideAssignee(assignee: any): void {
+    const currentAssignees: string[] = this.filtersService.filter$.value.assignees || [];
+    const updatedAssignees = currentAssignees.filter((login) => login !== assignee.login);
+    this.filtersService.updateFilters({ assignees: updatedAssignees });
+  }
+
+  hideMilestone(milestone: any): void {
+    console.log('Hide Milestone: ', milestone);
   }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -162,6 +162,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   }
 
   hideMilestone(milestone: any): void {
-    console.log('Hide Milestone: ', milestone);
+    const currentMilestones: string[] = this.filtersService.filter$.value.milestones || [];
+    const updatedMilestones = currentMilestones.filter((title) => title !== milestone.title);
+    this.filtersService.updateFilters({ milestones: updatedMilestones });
   }
 }

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
@@ -80,3 +80,7 @@
 .scrollable-container::after {
   position: sticky;
 }
+
+.show-button {
+  cursor: pointer;
+}

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -32,7 +32,7 @@
         }"
       ></div>
       <mat-card-title>{{ assignee.login }}</mat-card-title>
-      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above">
+      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above" (click)="showAssignee(assignee)">
         <span class="octicon" octicon="eye"></span>
       </div>
     </mar-card-header>
@@ -43,7 +43,7 @@
   <mat-card>
     <mar-card-header class="mat-card-header">
       <mat-card-title>{{ milestone.title }}</mat-card-title>
-      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above">
+      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above" (click)="showMilestone(milestone)">
         <span class="octicon" octicon="eye"></span>
       </div>
     </mar-card-header>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -32,7 +32,7 @@
         }"
       ></div>
       <mat-card-title>{{ assignee.login }}</mat-card-title>
-      <div class="show-assignee-button" matTooltip="Show Assignee" matTooltipPosition="above">
+      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above">
         <span class="octicon" octicon="eye"></span>
       </div>
     </mar-card-header>
@@ -43,6 +43,9 @@
   <mat-card>
     <mar-card-header class="mat-card-header">
       <mat-card-title>{{ milestone.title }}</mat-card-title>
+      <div class="show-button" [matTooltip]="getShowButtonTooltip()" matTooltipPosition="above">
+        <span class="octicon" octicon="eye"></span>
+      </div>
     </mar-card-header>
   </mat-card>
 </ng-template>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -32,6 +32,9 @@
         }"
       ></div>
       <mat-card-title>{{ assignee.login }}</mat-card-title>
+      <div class="show-assignee-button" matTooltip="Show Assignee" matTooltipPosition="above">
+        <span class="octicon" octicon="eye"></span>
+      </div>
     </mar-card-header>
   </mat-card>
 </ng-template>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,15 +1,15 @@
-import { AfterViewInit, Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { Group } from '../../core/models/github/group.interface';
-import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 import { FiltersService } from '../../core/services/filters.service';
+import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 
 @Component({
   selector: 'app-hidden-groups',
   templateUrl: './hidden-groups.component.html',
   styleUrls: ['./hidden-groups.component.css']
 })
-export class HiddenGroupsComponent implements AfterViewInit {
+export class HiddenGroupsComponent implements OnInit, AfterViewInit {
   @Input() groups: Group[] = [];
 
   @ViewChild('defaultCard') defaultCardTemplate: TemplateRef<any>;

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -35,4 +35,13 @@ export class HiddenGroupsComponent implements AfterViewInit {
         return this.defaultCardTemplate;
     }
   }
+
+  getShowButtonTooltip(): string {
+    if (this.groupingContextService.currGroupBy === GroupBy.Assignee) {
+      return 'Show Assignee';
+    } else if (this.groupingContextService.currGroupBy === GroupBy.Milestone) {
+      return 'Show Milestone';
+    }
+    return '';
+  }
 }

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,7 +1,8 @@
 import { AfterViewInit, Component, Input, TemplateRef, ViewChild } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { Group } from '../../core/models/github/group.interface';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
+import { FiltersService } from '../../core/services/filters.service';
 
 @Component({
   selector: 'app-hidden-groups',
@@ -16,8 +17,17 @@ export class HiddenGroupsComponent implements AfterViewInit {
   @ViewChild('milestoneCard') milestoneCardTemplate: TemplateRef<any>;
 
   private currentCardTemplate$ = new BehaviorSubject<TemplateRef<any>>(null);
+  private filterSubscription: Subscription;
 
-  constructor(public groupingContextService: GroupingContextService) {}
+  currentAssignees: string[] = [];
+
+  constructor(public groupingContextService: GroupingContextService, private filtersService: FiltersService) {}
+
+  ngOnInit() {
+    this.filterSubscription = this.filtersService.filter$.subscribe((filter) => {
+      this.currentAssignees = filter.assignees || [];
+    });
+  }
 
   ngAfterViewInit() {
     setTimeout(() => {
@@ -43,5 +53,17 @@ export class HiddenGroupsComponent implements AfterViewInit {
       return 'Show Milestone';
     }
     return '';
+  }
+
+  showAssignee(assignee: any): void {
+    const currentAssignees: string[] = this.filtersService.filter$.value.assignees || [];
+    if (!currentAssignees.includes(assignee.login)) {
+      const updatedAssignees = [...currentAssignees, assignee.login];
+      this.filtersService.updateFilters({ assignees: updatedAssignees });
+    }
+  }
+
+  showMilestone(milestone: any): void {
+    console.log('show milestone:', milestone);
   }
 }

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -64,6 +64,10 @@ export class HiddenGroupsComponent implements OnInit, AfterViewInit {
   }
 
   showMilestone(milestone: any): void {
-    console.log('show milestone:', milestone);
+    const currentMilestones: string[] = this.filtersService.filter$.value.milestones || [];
+    if (!currentMilestones.includes(milestone.title)) {
+      const updatedMilestones = [...currentMilestones, milestone.title];
+      this.filtersService.updateFilters({ milestones: updatedMilestones });
+    }
   }
 }


### PR DESCRIPTION
### Summary:
Created a Hide button that will allow the user to hide assignees or milestones without having to use the dropdown filter bar. 
Hidden assignees or milestones are now displayed with a Show button that allows the user to easily unhide them.

This will allow for a more intuitive approach to filtering out assignees or milestones, and could potentially reduce clutter in the filter bar and streamline the filtering process.

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Add Hide button within the assignee/milestone card
- Add Show button to hidden assignees/milestones within the hidden group

### Screenshots:
<details>
<summary>This is how the hiding and showing of assignees work:</summary>

<br>

![assignee-demo](https://github.com/user-attachments/assets/733c7717-dcbc-4ccc-8d1d-c701c8f7d76c)
</details>

<details>
<summary>This is how the hiding and showing of milestones work:</summary>

<br>

![milestone-demo](https://github.com/user-attachments/assets/fa4d3380-5c23-434c-92aa-2438f1642a98)
</details>

### Proposed Commit Message:

```
Add Show/Hide button for Assignees and Milestones in card view

Users currently have to use dropdown filters to control which 
assignees or milestones are visible.

This change adds a Show/Hide button directly within each assignee 
or milestone card, allowing users to toggle their visibility more 
intuitively.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
