### PR TITLE
Add assignees' usernames to tooltip in issue card

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -1,6 +1,6 @@
 <mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
   <a class="no-underline link-grey-dark">
-    <span [matTooltip]="this.issue.updated_at">
+    <span [matTooltip]="getIssueCardTooltip(this.issue)" matTooltipClass="multiline-tooltip">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>
     </span>
   </a>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -72,4 +72,9 @@ export class IssuePrCardComponent {
   isMergedWithoutReview(issue: Issue): boolean {
     return issue.issueOrPr === 'PullRequest' && issue.state === 'MERGED' && (!issue.reviews || issue.reviews.length === 0);
   }
+
+  getIssueCardTooltip(issue: Issue): string {
+    const assignees = issue.assignees && issue.assignees.length > 0 ? 'Assigned to: ' + issue.assignees.join(', ') : 'No assignees';
+    return `${assignees}\nLast updated at ${issue.updated_at}`;
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -170,3 +170,7 @@ table {
   max-width: 15%;
   min-width: 180px;
 }
+
+.multiline-tooltip {
+  white-space: pre-line;
+}


### PR DESCRIPTION
### Summary:
Grouping by milestone currently hides assignee information, requiring users to click each issue or PR card to view it on GitHub.

This PR improves usability by adding assignee names to the tooltip shown when hovering over an issue or PR card, alongside the last updated time.

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

* Issue card tooltip now shows both the assignees and the last updated time

* Handles display for both populated and empty assignee lists

### Screenshots:
This is what the tooltip shows when there are assignees:
![image](https://github.com/user-attachments/assets/a27c423b-5e0f-4902-995e-449de7782a2d)

This is what the tooltip shows when there are no assignees: 
![image](https://github.com/user-attachments/assets/1cb65456-e3c4-4664-bdcf-ae466aca5ca8)

### Proposed Commit Message:

```
Add assignees to issue tooltip

When grouping by milestone, assignees are not shown on issue 
cards, requiring users to open GitHub to view them.

This commit adds the issue's assignees to the card tooltip, alongside
the last updated time, to improve usability and visibility.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
